### PR TITLE
Fixing type error in pkg/build.ml

### DIFF
--- a/pkg/build.ml
+++ b/pkg/build.ml
@@ -3,7 +3,7 @@
 #use "topkg.ml";;
 
 let () =
-  Pkg.describe "ptime" ~builder:`OCamlbuild [
+  Pkg.describe "ptime" ~builder:(`OCamlbuild []) [
     Pkg.lib "pkg/META";
     Pkg.lib ~exts:Exts.module_library "src/ptime";
     Pkg.lib "src/ptime_top_init.ml";


### PR DESCRIPTION
Changed \`Ocamlbuild to (\`Ocamlbuild []) to match corresponding change in topkg.ml.