### PR TITLE
Windows support for Ptime_clock

### DIFF
--- a/src-os/ptime_clock_stubs.c
+++ b/src-os/ptime_clock_stubs.c
@@ -119,16 +119,16 @@ CAMLprim value ocaml_ptime_clock_now_d_ps (value unit)
   long sec, usec;
   SYSTEMTIME stime;
   FILETIME ftime;
-  uint64_t time;
+  ULARGE_INTEGER time;
 
   static const uint64_t epoch = ((uint64_t)116444736000000000ULL);
 
   GetSystemTime (&stime);
   SystemTimeToFileTime (&stime, &ftime);
-  time = ((uint64_t)ftime.dwLowDateTime) +
-         (((uint64_t)ftime.dwHighDateTime) << 32);
+  time.LowPart = ftime.dwLowDateTime;
+  time.HighPart = ftime.dwHighDateTime;
 
-  sec = (long)((time - epoch) / 10000000L);
+  sec = (long)((time.QuadPart - epoch) / 10000000L);
   usec = (long)(stime.wMilliseconds * 1000);
 
   if (usec < 0 || usec > 999999)

--- a/src-os/ptime_clock_stubs.c
+++ b/src-os/ptime_clock_stubs.c
@@ -31,7 +31,6 @@
 
 #elif defined(_WIN32)
   #define OCAML_PTIME_WIN
-  #include <sys/time.h>
   #include <windows.h>
 
 #else
@@ -129,7 +128,7 @@ CAMLprim value ocaml_ptime_clock_now_d_ps (value unit)
   time = ((uint64_t)ftime.dwLowDateTime) +
          (((uint64_t)ftime.dwHighDateTime) << 32);
 
-  sec  = (long)((time - epoch) / 10000000L);
+  sec = (long)((time - epoch) / 10000000L);
   usec = (long)(stime.wMilliseconds * 1000);
 
   if (usec < 0 || usec > 999999)

--- a/src-os/ptime_clock_stubs.c
+++ b/src-os/ptime_clock_stubs.c
@@ -121,14 +121,14 @@ CAMLprim value ocaml_ptime_clock_now_d_ps (value unit)
   FILETIME ftime;
   ULARGE_INTEGER time;
 
-  static const uint64_t epoch = ((uint64_t)116444736000000000ULL);
-
   GetSystemTime (&stime);
   SystemTimeToFileTime (&stime, &ftime);
   time.LowPart = ftime.dwLowDateTime;
   time.HighPart = ftime.dwHighDateTime;
 
-  sec = (long)((time.QuadPart - epoch) / 10000000L);
+#define EPOCH (116444736000000000)
+  sec = (long)((time.QuadPart - EPOCH) / 10000000L);
+#undef EPOCH
   usec = (long)(stime.wMilliseconds * 1000);
 
   if (usec < 0 || usec > 999999)

--- a/src-os/ptime_clock_stubs.c
+++ b/src-os/ptime_clock_stubs.c
@@ -126,7 +126,7 @@ CAMLprim value ocaml_ptime_clock_now_d_ps (value unit)
   time.LowPart = ftime.dwLowDateTime;
   time.HighPart = ftime.dwHighDateTime;
 
-#define EPOCH (116444736000000000)
+#define EPOCH (116444736000000000ULL)
   sec = (long)((time.QuadPart - EPOCH) / 10000000L);
 #undef EPOCH
   usec = (long)(stime.wMilliseconds * 1000);

--- a/src-os/ptime_clock_stubs.c
+++ b/src-os/ptime_clock_stubs.c
@@ -166,6 +166,8 @@ CAMLprim value ocaml_ptime_clock_period_d_ps (value unit)
 
 CAMLprim value ocaml_ptime_clock_current_tz_offset_s (value unit)
 {
+  CAMLparam1(unit);
+  CAMLlocal1(some);
   struct tm *tm;
 
   time_t now_utc = time (NULL);
@@ -186,15 +188,17 @@ CAMLprim value ocaml_ptime_clock_current_tz_offset_s (value unit)
        (dd == -1 || dd >  1 /* year wrap */) ? dm - (24 * 60) :
        dm /* same day */;
 
-  value some = caml_alloc (1, 0);
+  some = caml_alloc (1, 0);
   Store_field (some, 0, Val_int (dm * 60));
-  return some;
+  CAMLreturn(some);
 }
 
 #elif defined(OCAML_PTIME_WIN)
 
 CAMLprim value ocaml_ptime_clock_current_tz_offset_s (value unit)
 {
+  CAMLparam1(unit);
+  CAMLlocal1(some);
   TIME_ZONE_INFORMATION tz;
   int bias;
 
@@ -209,9 +213,9 @@ CAMLprim value ocaml_ptime_clock_current_tz_offset_s (value unit)
     OCAML_PTIME_RAISE_SYS_ERROR("GetTimeZoneInformation failed");
   }
 
-  value some = caml_alloc (1, 0);
+  some = caml_alloc (1, 0);
   Store_field (some, 0, Val_int (-bias * 60));
-  return some;
+  CAMLreturn(some);
 }
 
 #else /* OCAML_PTIME_UNSUPPORTED */

--- a/src-os/ptime_clock_stubs.c
+++ b/src-os/ptime_clock_stubs.c
@@ -252,6 +252,9 @@ CAMLprim value ocaml_ptime_clock_current_tz_offset_s (value unit)
   }
 
   some = caml_alloc (1, 0);
+  /* Note that on Windows 'bias' is defined as (UTC - localtime),
+   * while ptime uses (localtime - UTC)
+   */
   Store_field (some, 0, Val_int (-bias * 60));
   CAMLreturn(some);
 }


### PR DESCRIPTION
Partially implements #5 (Ptime_clock.period not implemented).