### PR TITLE
Fix Js_of_ocaml changes of namespace

### DIFF
--- a/src-jsoo/ptime_clock.ml
+++ b/src-jsoo/ptime_clock.ml
@@ -3,6 +3,7 @@
    Distributed under the ISC license, see terms at the end of the file.
    %%NAME%% %%VERSION%%
   ---------------------------------------------------------------------------*)
+open Js_of_ocaml
 
 let str = Printf.sprintf
 


### PR DESCRIPTION
js_of_ocaml version >= 3.4.0 removes the Js namespace and put everything in `Js_of_ocaml`. I'm not sure how my patch will affect older version of Js_of_ocaml but this fixes the issue for me