### PR TITLE
feat: add to_rfc1123 function

### DIFF
--- a/build
+++ b/build
@@ -35,7 +35,7 @@ action ()
             if [ "$1" = "-b" ]; then
                 topkg browse \
                 "http://localhost/ptime/test-jsoo/min_clock_jsoo.html"
-            fiOA
+            fi
             ;;
         doc)     shift; topkg doc --dev $* ;;
         api-doc) shift; topkg doc $* ;;


### PR DESCRIPTION
Hi @dbuenzli!

I've made an attempt at adding a string formatting function for RFC1123 which might solve #7 but please do go easy on me as this is my first attempt at contributing OCaml :sweat_smile: 

I have been unable to test my function as the build script initially failed with `./build: line 39: syntax error near unexpected token ;;'` and once I had removed `OA`, which I assume is a typo, I'm now met with:

```
❯ ./build
Solver failed:
  Ocamlbuild knows of no rules that apply to a target named src/ptime_top.mly. This can happen if you ask Ocamlbuild to build a target with the wrong extension (e.g. .opt instead of .native) or if the source files live in directories that have not been specified as include directories.
Backtrace:
  - Failed to build the target ptime_top.cma
      - Failed to build all of these:
          - Building src/ptime_top.cma:
              - Failed to build all of these:
                  - Building src/ptime_top.cmo:
                      - Failed to build all of these:
                          - Building src/ptime_top.ml:
                              - Failed to build all of these:
                                  - Building src/ptime_top.mly
                                  - Building src/ptime_top.mll
                          - Building src/ptime_top.mli:
                              - Building src/ptime_top.mly
                          - Building src/ptime_top.mlpack
                          - Building src/ptime_top.mli:
                              - Building src/ptime_top.mly
                  - Building src/ptime_top.mllib
          - Building ptime_top.cma:
              - Failed to build all of these:
                  - Building ptime_top.cmo:
                      - Failed to build all of these:
                          - Building ptime_top.ml:
                              - Failed to build all of these:
                                  - Building ptime_top.mly
                                  - Building ptime_top.mll
                          - Building ptime_top.mli:
                              - Building ptime_top.mly
                          - Building ptime_top.mlpack
                          - Building ptime_top.mli:
                              - Building ptime_top.mly
                  - Building ptime_top.mllib
```

Any idea what's going on here?

EDIT: The motivation for this is that I'm trying to add a test suite for [webmachine](https://github.com/inhabitedtype/ocaml-webmachine) to the [Tech Empower Benchmark](https://www.techempower.com/blog/2020/05/28/framework-benchmarks-round-19/) suite and I'm being met by:
```
WARN for http://tfb-server:8080/plaintext
     Invalid Date header, found "2020-09-19T23:42:19-00:00", did not match "%a, %d %b %Y %H:%M:%S %Z".
     See https://github.com/TechEmpower/FrameworkBenchmarks/wiki/Project-Information-Framework-Tests-Overview#specific-test-requirements
```