### PR TITLE
Expose `max_month_day` in the interface.

### DIFF
--- a/src/ptime.mli
+++ b/src/ptime.mli
@@ -309,6 +309,10 @@ type time = (int * int * int) * tz_offset_s
     A [time] value is said to be {e valid} iff the values [(hh, mm, ss)]
     are in the ranges mentioned above. *)
 
+val max_month_day : int -> int -> int
+(** [max_month_day year month] is the last day of the given [month] of
+   [year]. It can be 31, 30, 29 or 28. *)
+
 val of_date_time : date * time -> t option
 (** [of_date_time dt] is the POSIX timestamp corresponding to
     date-time [dt] or [None] if [dt] has an {{!date}invalid date},


### PR DESCRIPTION
When performing arithmetic operation on dates, I find it not practical with the current interface to add a fixed number of months to a date. Eg., find what "in two months" means with respect to the current date, since adding X month may end up with an invalid date if the day is out of bound. The only way I can figure out with the current interface is to increment the month, test if the date is valid with `Ptime.of_date`, and if not decrement the day by one and re-test, until we end up with a valid date, which doesn't look great.

Exposing `max_month_day` would make this much cleaner, as one could simply `min day (max_month_day day)`.

I'd argue that `month_max_day` could be a better name if we expose it, but that's nit.