### PR TITLE
Allow MSVC compiler to build

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,11 +9,7 @@
 * Handle `Pervasives` deprecation.
 * Fix `Ptime.truncate` to always truncate down. Thanks
   to David Kaloper Meršinjak for the report & fix.
-
-v0.8.6 2021-11-26 Jonah Beckford
---------------------------------
-
-* Allow compiling with MSVC compiler
+* Allow compiling with MSVC compiler. Jonah Beckford
 
 v0.8.5 2019-05-02 La Forclaz (VS)
 ---------------------------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,11 @@
 * Fix `Ptime.truncate` to always truncate down. Thanks
   to David Kaloper Meršinjak for the report & fix.
 
+v0.8.6 2021-11-26 Jonah Beckford
+--------------------------------
+
+* Allow compiling with MSVC compiler
+
 v0.8.5 2019-05-02 La Forclaz (VS)
 ---------------------------------
 

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -7,8 +7,10 @@ let system_support_lib = match os with
 | "Linux\n" -> [A "-cclib"; A "-lrt"]
 | _ -> []
 
-let lib_a = Ocamlbuild_pack.Ocamlbuild_config.a
-let clock_stubs_lib = "src-clock/os/libptime_clock_stubs." ^ lib_a
+let lib s =
+  match !Ocamlbuild_plugin.Options.ext_lib with
+  | "" -> s ^ ".a"
+  | x -> s ^ "." ^ x
 
 let js_rule () =
   let dep = "%.byte" in
@@ -34,10 +36,10 @@ let () =
       (* ptime_clock_os *)
 
       flag_and_dep ["link"; "ocaml"; "link_ptime_clock_os_stubs"]
-        (A clock_stubs_lib);
+        (A (lib "src-clock/os/libptime_clock_stubs"));
 
       dep ["record_ptime_clock_os_stubs"]
-        [clock_stubs_lib];
+        [lib "src-clock/os/libptime_clock_stubs"];
 
       flag ["library"; "ocaml"; "byte"; "record_ptime_clock_os_stubs"]
         (S ([A "-dllib"; A "-lptime_clock_stubs"] @ system_support_lib));

--- a/myocamlbuild.ml
+++ b/myocamlbuild.ml
@@ -7,6 +7,9 @@ let system_support_lib = match os with
 | "Linux\n" -> [A "-cclib"; A "-lrt"]
 | _ -> []
 
+let lib_a = Ocamlbuild_pack.Ocamlbuild_config.a
+let clock_stubs_lib = "src-clock/os/libptime_clock_stubs." ^ lib_a
+
 let js_rule () =
   let dep = "%.byte" in
   let prod = "%.js" in
@@ -31,10 +34,10 @@ let () =
       (* ptime_clock_os *)
 
       flag_and_dep ["link"; "ocaml"; "link_ptime_clock_os_stubs"]
-        (A "src-clock/os/libptime_clock_stubs.a");
+        (A clock_stubs_lib);
 
       dep ["record_ptime_clock_os_stubs"]
-        ["src-clock/os/libptime_clock_stubs.a"];
+        [clock_stubs_lib];
 
       flag ["library"; "ocaml"; "byte"; "record_ptime_clock_os_stubs"]
         (S ([A "-dllib"; A "-lptime_clock_stubs"] @ system_support_lib));


### PR DESCRIPTION
The original code was looking for `src-clock/os/libptime_clock_stubs.a`. But the MSVC compiler needs `src-clock/os/libptime_clock_stubs.lib`.

ocamlbuild (which I know little about) already has knowledge of `.a` versus `.lib` so I used that.