### PR TITLE
add jsoo stubs for ptime.clock.os

### DIFF
--- a/pkg/META
+++ b/pkg/META
@@ -32,6 +32,7 @@ package "clock" (
     archive(native) = "ptime_clock.cmxa"
     plugin(byte) = "ptime_clock.cma"
     plugin(native) = "ptime_clock.cmxs"
+    linkopts(javascript) = "+ptime.clock.os/runtime.js"
     exists_if = "ptime_clock.cma")
 
   package "jsoo" (

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -14,6 +14,7 @@ let () =
        Pkg.lib ~exts:Exts.interface "src/ptime_clock" ~dst:"clock/";
        Pkg.mllib "src-os/ptime_clock.mllib" ~dst_dir:"clock/os/";
        Pkg.clib "src-os/libptime_clock_stubs.clib" ~lib_dst_dir:"clock/os/";
+       Pkg.lib "src-os/runtime.js" ~dst:"clock/os/";
        Pkg.mllib ~cond:jsoo "src-jsoo/ptime_clock.mllib" ~dst_dir:"clock/jsoo/";
        Pkg.test "test/test";
        Pkg.test "test/test_unix";

--- a/src-os/runtime.js
+++ b/src-os/runtime.js
@@ -1,0 +1,42 @@
+
+//Provides: ocaml_ptime_clock_period_d_ps
+function ocaml_ptime_clock_period_d_ps(_unit) {
+  return 0;
+}
+
+//Provides: ocaml_ptime_clock_current_tz_offset_s
+function ocaml_ptime_clock_current_tz_offset_s(_unit) {
+  return [0, ((new Date()).getTimezoneOffset() * -60)]
+}
+
+//Provides: ocaml_ptime_clock_now_d_ps
+//Requires: caml_int64_of_int32, caml_int64_of_float
+//Requires: caml_int64_add, caml_int64_mul
+//Requires: caml_modf_float
+//Requires: caml_raise_sys_error
+function ocaml_ptime_clock_now_d_ps(_unit) {
+  function err (ms) {
+    caml_raise_sys_error("Ptime_clock: can't represent JavaScript timestamp "+ms);
+  }
+  var dmin = 0;
+  var dmax = 2932896;
+  var ms = Date.now();
+  var ps;
+  if(ms != ms) err(ms)
+  var days = Math.floor (ms / 86400000);
+  if(days < dmin || days > dmax) err(ms);
+  var rem_ms = ms % 86400000;
+  if(rem_ms < 0) rem_ms += 86400000
+  if(rem_ms>=86400000) {
+    days += 1;
+    if(days > dmax) err(ms);
+    ps = caml_int64_of_int32(0);
+  }
+  else {
+    var modf = caml_modf_float(rem_ms);
+    var fract_ps = caml_int64_of_float(modf[1] * 1e9);
+    var rem_ps = caml_int64_mul(caml_int64_of_float(modf[2]),caml_int64_of_int32(1000000000));
+    ps = caml_int64_add (rem_ps, fract_ps);
+  }
+  return [0, days, ps]
+}

--- a/test-os/min_clock_os.ml
+++ b/test-os/min_clock_os.ml
@@ -4,7 +4,11 @@
    ocamlfind ocamlc \
      -package ptime.clock.os -linkpkg -o min_clock_os.byte min_clock_os.ml
    ocamlfind ocamlopt \
-     -package ptime.clock.os -linkpkg -o min_clock_os.native min_clock_os.ml *)
+     -package ptime.clock.os -linkpkg -o min_clock_os.native min_clock_os.ml
+   js_of_ocaml \
+     $(ocamlfind query ptime.clock.os -predicates javascript -o-format -r | xargs echo) \
+     min_clock_os.byte
+ *)
 
 let pp_period ppf = function
 | None -> Format.fprintf ppf "unknown"


### PR DESCRIPTION
fix #24.

This PR only adds necessary stubs to make ptime.clock.os work with jsoo.

This PR does not, remove/deprecate ptime.clock.jsoo  