### PR TITLE
Update META to fix dune support

### DIFF
--- a/pkg/META
+++ b/pkg/META
@@ -33,5 +33,6 @@ package "clock" (
     plugin(byte) = "ptime_clock.cma"
     plugin(native) = "ptime_clock.cmxs"
     linkopts(javascript) = "+ptime.clock.os/runtime.js"
+    jsoo_runtime = "runtime.js"
     exists_if = "ptime_clock.cma")
 )


### PR DESCRIPTION
I've missed the part that allows proper dune support for the jsoo stubs.